### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.1",
     "gulp-util": "^3.0.7",
-    "gulpicon": "^0.1.2",
+    "gulpicon": "^1.0.0",
     "imagemin-pngquant": "^4.2.0"
   }
 }


### PR DESCRIPTION
On macOS Sierra the old version of gulpicon doesn't work.
